### PR TITLE
fix Encode manipulator to make sure to interlace image if necessary

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -2,6 +2,7 @@
 
 namespace League\Glide\Api;
 
+use Intervention\Image\EncodedImage;
 use Intervention\Image\ImageManager;
 use League\Glide\Manipulators\ManipulatorInterface;
 
@@ -91,7 +92,7 @@ class Api implements ApiInterface
      *
      * @return string Manipulated image binary data.
      */
-    public function run($source, array $params)
+    public function run($source, array $params): EncodedImage
     {
         $image = $this->imageManager->read($source);
 
@@ -101,6 +102,6 @@ class Api implements ApiInterface
             $image = $manipulator->run($image);
         }
 
-        return $image->encodeByMediaType()->toString();
+        return $image->encodeByMediaType();
     }
 }

--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -34,7 +34,6 @@ class Encode extends BaseManipulator
                 ->place($image, 'top-left', 0, 0);
         }
 
-
         if (in_array($format, ['png', 'pjpg'], true)) {
             $shouldInterlace = true;
 

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -278,8 +278,7 @@ class ServerFactory
             new Watermark($this->getWatermarks(), $this->getWatermarksPathPrefix() ?: ''),
             new Background(),
             new Border(),
-            // TODO: Encoding was moved to Api::run()
-            // new Encode(),
+            new Encode(),
         ];
     }
 


### PR DESCRIPTION
Hi @Art4 ,

I made this additional change to make sure it will create interlaced PNGS / progressive JPGS if needed.

The old strategy I made was losing the interlace information when saving the image.

**Background:**

Sinve intervention v3 changed strategy about encoding image, it was necessary to create a new Image instance from scratch on Glide Encode manipulator.

On https://github.com/Art4/glide/blob/upgrade-to-glide-3/src/Manipulators/Encode.php#L49-L51
```php
return (new ImageManager($driver))->read(
            $image->encodeByExtension($format, $quality)->toString()
        );
```

The `read` method will try to read the image using several Decoders until find the best suitable for it. When it finds, it will read the image blob. But there is a catch w/ Image Magick: when it reads back image, it will scratch any interlace info if present. 

**Solution:**

Change the interlace checking after reading the encoded image, to make sure the interlaced information will persist.